### PR TITLE
.messageまわりのスタイル調整

### DIFF
--- a/app/frontend/stylesheets/application.css.scss
+++ b/app/frontend/stylesheets/application.css.scss
@@ -47,3 +47,44 @@ html, body {
   overflow-y: scroll;
   height: 100%;
 }
+
+.message-list ul {
+  list-style-type: none;
+}
+    
+.message {
+  -moz-user-select: text;
+  background: #eee;
+  border-color: transparent -moz-use-text-color;
+  border-style: solid none;
+  border-width: 1px medium;
+  color: #2c2d30;
+  display: block;
+  font-family: Slack-Lato,appleLogo,sans-serif;
+  font-size: 0.9375rem;
+  line-height: 1.375rem;
+  margin: 0 auto 1.2rem;
+  overflow-wrap: break-word;
+  padding: 0.0625rem 2.5rem 0.125rem 0;
+  position: relative;
+  width: 100%;
+  
+  div {margin-left: 4.5rem;} /* Slackの.message_contentに当たる部分 */
+  .message-icon{
+    margin-top: 0.25rem;
+    margin-left: 0;
+    display: block;
+    padding-right: 0.625rem;
+    width: 4rem;
+    left: 0;
+    position: absolute;
+    text-align: right;
+    top: 0; 
+      img{
+        border-radius: 0.2rem;
+      }
+    }
+    
+  }
+
+


### PR DESCRIPTION
メッセージカード風にするために、.messageまわりの基本的な配置を整えました
色は仮置きです
![komonjo](https://cloud.githubusercontent.com/assets/22927920/20264405/b62b6aae-aaae-11e6-94bc-839645caddac.png)
